### PR TITLE
Unit test suite for status service

### DIFF
--- a/src/main/java/dk/cngroup/lentils/service/StatusService.java
+++ b/src/main/java/dk/cngroup/lentils/service/StatusService.java
@@ -21,7 +21,7 @@ public class StatusService {
     }
 
     public void markCypher(final Cypher cypher, final Team team, final CypherStatus cypherStatus) {
-        Status status = statusRepository.findByTeamAndCypher(team, cypher);
+        Status status = getTeamCypherStatus(team, cypher);
         saveNewStatus(status, cypherStatus);
     }
 
@@ -30,18 +30,21 @@ public class StatusService {
     }
 
     public int getStatusScore(final Team team, final Cypher cypher) {
+        return getTeamCypherStatus(team, cypher).getCypherStatus().getStatusValue();
+    }
+
+    private Status getTeamCypherStatus(final Team team, final Cypher cypher) {
         Status status = statusRepository.findByTeamAndCypher(team, cypher);
-        return status.getCypherStatus().getStatusValue();
+        if (status == null) {
+            throw new IllegalStateException("No status found for the given cypher and team in database");
+        }
+
+        return status;
     }
 
     private void saveNewStatus(final Status status, final CypherStatus newStatus) {
         status.setCypherStatus(newStatus);
         statusRepository.save(status);
-    }
-
-    public CypherStatus getCypherStatusForTeam(final Cypher cypher, final Team team) {
-        Status status = statusRepository.findByTeamAndCypher(team, cypher);
-        return status.getCypherStatus();
     }
 
     public void initializeStatusForTeamAndCypher(final Cypher cypher, final Team team) {


### PR DESCRIPTION
PR fixes #120 

Rozšířená sada testů pro StatusService.

- Třída změněna na Unit test
- Doplněny testy pro větší pokrytí
- Odstraněna nepoužítá metoda StatusService::getCypherStatusForTeam
- Doplněná kontrola parametrů v některých metodách třídy StatusService pro zabránění NPE