### PR TITLE
Fix cypher URLs

### DIFF
--- a/src/main/java/dk/cngroup/lentils/controller/CypherController.java
+++ b/src/main/java/dk/cngroup/lentils/controller/CypherController.java
@@ -53,7 +53,7 @@ public class CypherController {
         return VIEW_CYPHER_DETAIL;
     }
 
-    @PostMapping(value = "/add")
+    @PostMapping(value = "/save")
     public String saveCypher(@Valid @ModelAttribute final Cypher cypher,
                              final BindingResult bindingResult,
                              final Model model) {

--- a/src/main/resources/templates/cypher/form.html
+++ b/src/main/resources/templates/cypher/form.html
@@ -23,7 +23,7 @@
         </div>
         <div class="row">
             <div class="col-sm-6">
-                <form action="#" th:action="@{/admin/cypher/add}" th:object="${cypher}" method="post">
+                <form action="#" th:action="@{/admin/cypher/save}" th:object="${cypher}" method="post">
                     <div class="form-group">
                         <label for="cypherId">Id</label>
                         <input id="cypherId" class="form-control" th:field="*{cypherId}" readonly/>


### PR DESCRIPTION
Cypher is sharing template for add and update, so POST /add endpoint
was renamed to /save.