### PR TITLE
fix finalplace security, add finalplace button if no next cypher

### DIFF
--- a/src/main/java/dk/cngroup/lentils/config/WebSecurityConfiguration.java
+++ b/src/main/java/dk/cngroup/lentils/config/WebSecurityConfiguration.java
@@ -49,7 +49,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests().antMatchers("/game/**")
                     .hasRole("ORGANIZER").and()
                 .authorizeRequests().antMatchers("/finalplace")
-                    .hasRole("ORGANIZER").and()
+                    .hasRole("USER").and()
                 .authorizeRequests().antMatchers("/contact**")
                     .hasRole("USER").and()
                 .formLogin()

--- a/src/main/resources/templates/client/cypher/detail.html
+++ b/src/main/resources/templates/client/cypher/detail.html
@@ -45,7 +45,11 @@
                             Tuto šifru jste přeskočili
                         </div>
 
-                        <!--TODO co kdyz neni dalsi sifra? -> nezobrazovat, ale mohlo by se zobrazit final place-->
+                        <div th:unless="${nextCypher}">
+                            <a class="btn btn-primary" th:href="@{/finalplace}"
+                               role="button">Vyhlášení výsledků </button></a>
+                        </div>
+
                         <div th:if="${nextCypher}">
                             <h2>Kam dál?</h2>
                             <a class="btn btn-primary" th:href="@{'/cypher/' + ${nextCypher.cypherId}}"
@@ -58,7 +62,11 @@
                             Zadali jste správné heslo. Šifra byla vyluštěna!
                         </div>
 
-                        <!--TODO co kdyz neni dalsi sifra? -> nezobrazovat, ale mohlo by se zobrazit final place-->
+                        <div th:unless="${nextCypher}">
+                            <a class="btn btn-primary" th:href="@{/finalplace}"
+                               role="button">Vyhlášení výsledků </button></a>
+                        </div>
+
                         <div th:if="${nextCypher}">
                             <h2>Kam dál?</h2>
                             <a class="btn btn-primary" th:href="@{'/cypher/' + ${nextCypher.cypherId}}"


### PR DESCRIPTION
fixes #269 fixes #268   Problém byl ve špatném nastavení websecurity, kde to bylo přístupné jen pro organizátory místo userů. 
Přidány tlačítka pro zobrazení screenu místa vyhlášení.