### PR TITLE
#319 Unit test for deleting team

### DIFF
--- a/src/main/java/dk/cngroup/lentils/repository/HintTakenRepository.java
+++ b/src/main/java/dk/cngroup/lentils/repository/HintTakenRepository.java
@@ -20,4 +20,6 @@ public interface HintTakenRepository extends JpaRepository<HintTaken, HintTakenK
             "WHERE ht.team_team_id = ?1 AND h.cypher_id = ?2",
             nativeQuery = true)
     List<HintTaken> findAllByTeamAndCypher(Long teamId, Long cypherId);
+
+    void deleteAllByTeamTeamId(Long teamId);
 }

--- a/src/main/java/dk/cngroup/lentils/repository/StatusRepository.java
+++ b/src/main/java/dk/cngroup/lentils/repository/StatusRepository.java
@@ -17,5 +17,6 @@ public interface StatusRepository extends JpaRepository<Status, StatusKey> {
     List<Status> findByTeam(Team team);
     Boolean existsStatusByCypherAndTeam(Cypher cypher, Team team);
     void deleteAllByCypherCypherId(Long cypherId);
+    void deleteAllByTeamTeamId(Long teamId);
     List<Status> findByTeamAndCypherStatus(Team team, CypherStatus cypherStatus);
 }

--- a/src/main/java/dk/cngroup/lentils/service/StatusService.java
+++ b/src/main/java/dk/cngroup/lentils/service/StatusService.java
@@ -102,4 +102,8 @@ public class StatusService {
     public void deleteAllByCypherId(final Long cypherId) {
         statusRepository.deleteAllByCypherCypherId(cypherId);
     }
+
+    public void deleteAllByTeamId(final Long teamId) {
+        statusRepository.deleteAllByTeamTeamId(teamId);
+    }
 }

--- a/src/main/java/dk/cngroup/lentils/service/TeamService.java
+++ b/src/main/java/dk/cngroup/lentils/service/TeamService.java
@@ -3,11 +3,13 @@ package dk.cngroup.lentils.service;
 import dk.cngroup.lentils.entity.Team;
 import dk.cngroup.lentils.entity.User;
 import dk.cngroup.lentils.exception.ResourceNotFoundException;
+import dk.cngroup.lentils.repository.HintTakenRepository;
 import dk.cngroup.lentils.repository.TeamRepository;
 import dk.cngroup.lentils.util.UsernameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
@@ -25,14 +27,20 @@ public class TeamService {
     private static final String NAME_PROPERTY = "name";
 
     private final TeamRepository teamRepository;
+    private final HintTakenRepository hintTakenRepository;
+    private final StatusService statusService;
     private final PasswordEncoder passwordEncoder;
     private final RoleService roleService;
 
     @Autowired
     public TeamService(final TeamRepository teamRepository,
+                       final HintTakenRepository hintTakenRepository,
+                       final StatusService statusService,
                        final PasswordEncoder passwordEncoder,
                        final RoleService roleService) {
         this.teamRepository = teamRepository;
+        this.hintTakenRepository = hintTakenRepository;
+        this.statusService = statusService;
         this.passwordEncoder = passwordEncoder;
         this.roleService = roleService;
     }
@@ -66,7 +74,10 @@ public class TeamService {
         throw new ResourceNotFoundException(Team.class.getSimpleName(), id);
     }
 
+    @Transactional
     public void delete(final Long id) {
+        statusService.deleteAllByTeamId(id);
+        hintTakenRepository.deleteAllByTeamTeamId(id);
         teamRepository.deleteById(id);
     }
 


### PR DESCRIPTION
Fixes #319 

V metodě TeamService::delete() se nejdřív mažou všechny záznamy v Status a HintTaken navázané na tým a až poté samotný tým.

Metoda by měla celá běžet v transakci.