### PR TITLE
Add equals() and hashCode() for key entities

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/CypherGameInfoKey.java
+++ b/src/main/java/dk/cngroup/lentils/entity/CypherGameInfoKey.java
@@ -1,6 +1,7 @@
 package dk.cngroup.lentils.entity;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class CypherGameInfoKey implements Serializable {
     private Long cypherId;
@@ -20,5 +21,25 @@ public class CypherGameInfoKey implements Serializable {
 
     public Long getTeamId() {
         return teamId;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CypherGameInfoKey that = (CypherGameInfoKey) o;
+
+        return cypherId.equals(that.cypherId) &&
+                teamId.equals(that.teamId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cypherId, teamId);
     }
 }

--- a/src/main/java/dk/cngroup/lentils/entity/StatusKey.java
+++ b/src/main/java/dk/cngroup/lentils/entity/StatusKey.java
@@ -1,6 +1,7 @@
 package dk.cngroup.lentils.entity;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class StatusKey implements Serializable {
     private Long cypher;
@@ -20,5 +21,25 @@ public class StatusKey implements Serializable {
 
     public Long getTeam() {
         return team;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StatusKey statusKey = (StatusKey) o;
+
+        return cypher.equals(statusKey.cypher) &&
+                team.equals(statusKey.team);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cypher, team);
     }
 }


### PR DESCRIPTION
Vygenerovano equals and hashCode metody.

Log obsahoval nasledujici upozorneni:
HHH000038: Composite-id class does not override equals(): dk.cngroup.lentils.entity.StatusKey
HHH000039: Composite-id class does not override hashCode(): dk.cngroup.lentils.entity.StatusKey
HHH000038: Composite-id class does not override equals(): dk.cngroup.lentils.entity.CypherGameInfoKey
HHH000039: Composite-id class does not override hashCode(): dk.cngroup.lentils.entity.CypherGameInfoKey