### PR TITLE
[Fix] Remove invalid attribute 'type' on a tag

### DIFF
--- a/src/main/resources/templates/client/fragments/header.html
+++ b/src/main/resources/templates/client/fragments/header.html
@@ -5,7 +5,7 @@
 <body>
 <div th:fragment="header(activeTab, parentScreen)">
     <nav class="navbar navbar-default navbar-red">
-        <a th:unless="${parentScreen} == ''"  th:href="${parentScreen}" class="btn back" type="button">
+        <a th:unless="${parentScreen} == ''"  th:href="${parentScreen}" class="btn back" role="button">
             <i class="fas fa-chevron-left text-white"></i>
         </a>
 


### PR DESCRIPTION
Validator hlásí, že atribut type není na tagu a validní. Proto jsem ho odstranil.
Pokud tam byl přidaný záměrně, např kvůli stylu nebo tak, dejte prosím vědět.