### PR TITLE
GH-364 Differentiate progress badges with colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# CHANGELOG
+
+## v1.0.3
+
+### Features:
+
+### Fixes:
+
+### Other:
+- Barevné odlišení badge elementů v sekci organizátora pro přehled týmu
+ s informacemi o jejich stavu 
+
+## v1.0.2
+
+### Features:
+
+### Fixes:
+- Zobrazení přehledu týmu v sekci oragnizátora, pokud ani jeden
+tým není ve stavu progress
+
+### Other:
+- 
+
+## v1.0.1
+
+### Features:
+- Řazení nápověd vzestupně podle počtu bodů
+
+### Fixes:
+- Zobrazení obrázku nápovědy, pokud nebyl u šifry vyplněn
+
+### Other:
+- 

--- a/src/main/java/dk/cngroup/lentils/entity/TeamProgress.java
+++ b/src/main/java/dk/cngroup/lentils/entity/TeamProgress.java
@@ -1,7 +1,7 @@
 package dk.cngroup.lentils.entity;
 
 public interface TeamProgress {
+    String getIdentifier();
 
     String toString();
-
 }

--- a/src/main/java/dk/cngroup/lentils/entity/TeamProgressFinished.java
+++ b/src/main/java/dk/cngroup/lentils/entity/TeamProgressFinished.java
@@ -3,6 +3,11 @@ package dk.cngroup.lentils.entity;
 public class TeamProgressFinished implements TeamProgress {
 
     @Override
+    public String getIdentifier() {
+        return "finished";
+    }
+
+    @Override
     public String toString() {
         return "Hra ukončena";
     }

--- a/src/main/java/dk/cngroup/lentils/entity/TeamProgressNotStarted.java
+++ b/src/main/java/dk/cngroup/lentils/entity/TeamProgressNotStarted.java
@@ -3,6 +3,11 @@ package dk.cngroup.lentils.entity;
 public class TeamProgressNotStarted implements TeamProgress {
 
     @Override
+    public String getIdentifier() {
+        return "not-started";
+    }
+
+    @Override
     public String toString() {
         return "Hra nezahájena";
     }

--- a/src/main/java/dk/cngroup/lentils/entity/TeamProgressPlaying.java
+++ b/src/main/java/dk/cngroup/lentils/entity/TeamProgressPlaying.java
@@ -9,6 +9,11 @@ public class TeamProgressPlaying implements TeamProgress {
     }
 
     @Override
+    public String getIdentifier() {
+        return "in-progress";
+    }
+
+    @Override
     public String toString() {
         return "Aktuální stage: " + actualStage;
     }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -271,6 +271,18 @@ span.status {
     border-radius: 2px;
 }
 
+.team-status-badge-in-progress {
+    background-color: #0095ff !important;
+}
+.team-status-badge-finished {
+    color: black !important;
+    background-color: lawngreen !important;
+}
+
+.team-status-badge-not-started {
+    background-color: #757575 !important;
+}
+
 .pending span.status {
     background-color: #0095ff;
 }

--- a/src/main/resources/templates/progress/teamList.html
+++ b/src/main/resources/templates/progress/teamList.html
@@ -58,7 +58,10 @@
                     <div class="row align-items-center">
                         <div th:text="${teamProgress.getTeam().getName()}" class="col"></div>
                         <div class="col text-right">
-                            <div th:text="${teamProgress.getTeamProgress()}" class="team-status"></div>
+                            <div th:text="${teamProgress.getTeamProgress()}"
+                                 class="team-status"
+                                 th:classappend="|team-status-badge-${teamProgress.getTeamProgress().getIdentifier()}|">
+                            </div>
                         </div>
                     </div>
                 </a>


### PR DESCRIPTION
Fixes #364 

Takhle to nyní vypadá:
![badge-colors](https://user-images.githubusercontent.com/46486968/58325702-dd6ac900-7e2a-11e9-8478-f535db63ea7d.jpg)

Jsem graficky negramotný, takže jestli bude mít kdokoliv nápad na lepší barvičku, sem s tím.