### PR TITLE
Fixed finding next cypher by id and not by stage number

### DIFF
--- a/src/main/java/dk/cngroup/lentils/repository/CypherRepository.java
+++ b/src/main/java/dk/cngroup/lentils/repository/CypherRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Repository
 public interface CypherRepository extends JpaRepository<Cypher, Long> {
     Cypher findByStage(int stage);
-    Cypher findFirstByStageGreaterThan(int stage);
+    Cypher findFirstByStageGreaterThanOrderByStageAsc(int stage);
     List<Cypher> findAllByOrderByStageAsc();
     Cypher findFirstByOrderByStageAsc();
 }

--- a/src/main/java/dk/cngroup/lentils/service/CypherService.java
+++ b/src/main/java/dk/cngroup/lentils/service/CypherService.java
@@ -32,7 +32,7 @@ public class CypherService {
     }
 
     public Cypher getNext(final Integer stage) {
-        return cypherRepository.findFirstByStageGreaterThan(stage);
+        return cypherRepository.findFirstByStageGreaterThanOrderByStageAsc(stage);
     }
 
     public boolean checkCodeword(final Cypher cypher, final String codeword) {

--- a/src/test/java/dk/cngroup/lentils/service/CypherServiceIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/service/CypherServiceIntegrationTest.java
@@ -71,6 +71,20 @@ public class CypherServiceIntegrationTest {
         assertNull(result);
     }
 
+    @Test
+    public void getNextCypherWhenCyphersHasBeenCreatedInRandomOrder() {
+        final Cypher first = getCypherWithStageNumber(1);
+        final Cypher fourth = getCypherWithStageNumber(4);
+        final Cypher third = getCypherWithStageNumber(3);
+        final Cypher second = getCypherWithStageNumber(2);
+
+
+        final Cypher result = testedService.getNext(first.getStage());
+
+        assertNotNull(result);
+        assertEquals(second.getStage(), result.getStage());
+    }
+
     /**
      * This tests #65
      * Cypher with Status record could not be deleted due to incorrect FK constrains.


### PR DESCRIPTION
Refs #384 

Query vratilo vsechny sifry, kde stage je vetsi nez aktualni stage a vzalo prvni radek. Problem byl, ze ta mnozina sifer se stage vetsi nez aktualni nebylo serazene, takze to vratilo proste prvni sifru, ktera to stage ma vetsi. Staci pridat serazeni a uz to bezi jak ma ;)