### PR TITLE
GH-387 [Design] Clickable email for client in contact view

### DIFF
--- a/src/main/resources/templates/client/contact.html
+++ b/src/main/resources/templates/client/contact.html
@@ -17,7 +17,7 @@
                 </li>
                 <li>
                     <i class="fas fa-envelope"></i>
-                    <span th:text="${contact.email}">email@email.com</span>
+                    <a href="#" th:href="${'mailto:' + contact.email}" th:text="${contact.email}">email@email.com</a>
                 </li>
             </ul>
             <h2>Odkazy</h2>


### PR DESCRIPTION
Fixes #387 

Teď to vypadá takhle a odkaz je klikatelný (s prefixem mailto):

![contact_email_link](https://user-images.githubusercontent.com/46486968/58855088-64c40200-869f-11e9-87c8-dc375b2eadc6.jpg)
