### PR TITLE
GH-383 [Design] Fix company logo on login page for small viewports

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -532,11 +532,17 @@ td .btn-default {
 
 /** Login page */
 .login-page-body {
+    position: relative;
+    min-height:100%;
     background-image: url('/img/login-background-mobile-large.jpg');
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
     background-attachment: fixed;
+}
+
+.login-form-container {
+    padding-bottom:150px
 }
 /* Provide different image sizes for different screens to save bandwidth*/
 @media (min-width: 576px) {

--- a/src/main/resources/templates/login/login.html
+++ b/src/main/resources/templates/login/login.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="cs" xmlns:th="http://www.thymeleaf.org">
+<html lang="cs" xmlns:th="http://www.thymeleaf.org" style="height:100%">
 <head th:replace="fragments/head :: head('Luštěniny - přihlášení')">
 </head>
 <body class="login-page-body">
-    <div class="container">
+    <div class="container login-form-container">
         <div class="row">
             <div class="col-sm-12">
                 <h1 class="login-form-header">Luštěniny</h1>
@@ -30,8 +30,8 @@
             </div>
         </div>
     </div>
-    <div class="login-footer">
+    <footer class="login-footer">
         <img src="../../static/img/cngroup-logo.png" th:src="@{/img/cngroup-logo.png}" alt="CN Group Zlin" />
-    </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
Fixes #383 

Změnil jsem CSS tak, aby mezi tlačítkem Login a logem byla vždy mezera alespoň 150px (ta byla zvolena od oka a podle mého mobilu :) ).

Pokud se mobil otočí na šířku a viewport má tak malou šířku, logo je pořád pod tlačítkem a stránka pak jde skrolovat dolů, kde může být logo vidět.

Dříve se logo prostě vykreslilo pod prvky formuláře a nevypadalo to moc dobře.