### PR TITLE
GH-385 [Fix] Do redirect after organizer change status of cypher

### DIFF
--- a/src/main/java/dk/cngroup/lentils/controller/ProgressController.java
+++ b/src/main/java/dk/cngroup/lentils/controller/ProgressController.java
@@ -126,7 +126,8 @@ public class ProgressController {
         model.addAttribute("teams", progressService.getSearchedTeams(searchString));
         model.addAttribute("teamsStatuses", progressService.getTeamsStatuses(cypher));
         model.addAttribute("search", searchString);
-        return PROGRESS_STAGE;
+
+        return "redirect:/game/progress/stage?cypherId=" + cypherId + "&search=" + searchString;
     }
 
     @GetMapping(value = "/viewHints/{cypherId}")


### PR DESCRIPTION
Refs #385 

Teď se po změně stavu provede REDIRECT a nerecykluje se view.
Prohlížeč pak po refreshi nebo stisknutí tlačítka zpět neposílá znovu request na /game/progress/changeStatus a vse vypada OK a nestalo se mě, že by šlo nechtě operaci znovu provést.
