### PR TITLE
Change deprecated media queries attributes

### DIFF
--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -17,9 +17,9 @@
     <link rel="apple-touch-icon" sizes="167x167" href="apple-touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes="120x120" href="apple-touch-icon-120x120.png">
     <!-- iPhone X, Xs (1125px x 2436px) -->
-    <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" href="/apple-launch-1125x2436.png">
+    <link rel="apple-touch-startup-image" media="(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)" href="/apple-launch-1125x2436.png">
     <!-- iPhone 8, 7, 6s, 6 (750px x 1334px) -->
-    <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="/apple-launch-750x1334.png">
+    <link rel="apple-touch-startup-image" media="(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)" href="/apple-launch-750x1334.png">
     <title th:text="${title}"> </title>
 </head>
 </html>


### PR DESCRIPTION
Nahradil jsem deprecated media queries atributy.
https://drafts.csswg.org/mediaqueries/#mf-deprecated

Možná bych na iOS ještě vyzkoušel.