### PR TITLE
GH-425 [Fix] Incorrect accordion widget markup in organizer view

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -493,22 +493,21 @@ td .btn-default {
     width: 100%;
 }
 
-.accordion {
-    margin-bottom: 8px;
+.cypher-codeword-accordion {
+    margin-bottom: 15px;
 }
 
-.card-header {
-    background-color: white;
-    text-align: center;
-    font-size: 1rem;
-    padding: 0.25rem;
+/** Note: This is a hotfix for style: .container .row .btn */
+.accordion-header-btn {
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }
+/** End of hotfix**/
 
-.card-header:hover {
-    cursor: pointer;
-}
-
-#collapseOne {
+.collapse-sm-content {
     text-align: center;
     font-size: 1rem;
     padding: 0.25rem;

--- a/src/main/resources/templates/progress/stage.html
+++ b/src/main/resources/templates/progress/stage.html
@@ -8,15 +8,18 @@
     <div class="row">
         <div class="col-sm-12 col-md-6">
             <h1 th:text="${cypher.name}"></h1>
-            <div class="accordion" id="codewordAccordion">
+            <div class="cypher-codeword-accordion" id="codewordAccordion">
                 <div class="card">
-                    <div class="card-header" id="headingOne" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                        Zobrazit řešení šifry
+                    <div class="card-header" id="headingOne">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link accordion-header-btn" data-toggle="collapse" data-target="#cypherCodewordPanel" aria-expanded="false" aria-controls="collapseOne">
+                                Zobrazit řešení šifry
+                            </button>
+                        </h5>
                     </div>
-                    <div th:text="${cypher.codeword}" id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#codewordAccordion">
+                    <div id="cypherCodewordPanel" class="collapse" aria-labelledby="headingOne" data-parent="#codewordAccordion">
+                        <div class="card-body collapse-sm-content" th:text="${cypher.codeword}">Secret</div>
                     </div>
-                </div>
-                <div class="card">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Refs #425

Upravil jsem HTML pro accordion podle https://getbootstrap.com/docs/4.0/components/collapse/.

Vypadá to trochu jinak, upravil jsem i některé styly.

Hlavní oprava byla v tom, že v Safari nefungovalo to tlačítko. Prej by to neměl být div, ale button. Proto takhle změna.

Potřeba pak vyzkoušet na Apple zařízení.