### PR TITLE
GH-444 Add new field finishTime to finalplace + test adaption

### DIFF
--- a/src/main/java/dk/cngroup/lentils/controller/ClientController.java
+++ b/src/main/java/dk/cngroup/lentils/controller/ClientController.java
@@ -228,7 +228,7 @@ public class ClientController {
                                                   final Model model) {
         if (gameLogicService.allowPlayersToViewFinalPlace(user.getTeam())) {
             model.addAttribute("finalViewAllowed", true);
-            model.addAttribute("openingTime", gameLogicService.getFinalPlaceOpeningTime());
+            model.addAttribute("resultsTime", gameLogicService.getFinalPlaceResultsTime());
         }
     }
 }

--- a/src/main/java/dk/cngroup/lentils/controller/FinalPlaceController.java
+++ b/src/main/java/dk/cngroup/lentils/controller/FinalPlaceController.java
@@ -41,6 +41,7 @@ public class FinalPlaceController {
     public String saveFinalPlace(@Valid @ModelAttribute final FinalPlace finalPlace,
                                  final BindingResult bindingResult,
                                  final Model model) {
+        finalPlaceService.checkFinishTimeBeforeResultsTime(bindingResult, finalPlace);
         if (bindingResult.hasErrors()) {
             model.addAttribute("finalPlace", finalPlace);
             return VIEW_FINALPLACE_FORM;

--- a/src/main/java/dk/cngroup/lentils/entity/FinalPlace.java
+++ b/src/main/java/dk/cngroup/lentils/entity/FinalPlace.java
@@ -27,21 +27,37 @@ public class FinalPlace {
     @NotNull(message = "Souřadnice nesmí být prázdné.")
     private Point location;
 
-    @Column(name = "opening_time")
+    @Column(name = "results_time")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime openingTime;
+    private LocalDateTime resultsTime;
+
+    @Column(name = "access_time")
+//    @NotNull(message = "Zpřístupnění nesmi být prázdné.")
+//    @Min(value = 0, message = "Zpřístupnění nesmí být záporné.")
+//    po odkomentovani odstranit hodnotu 1
+    private Integer accessTime = 1;
+
+    @Column(name = "finish_time")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime finishTime;
 
     public FinalPlace() {
     }
 
-    public FinalPlace(final String description, final Point location, final LocalDateTime openingTime) {
+    public FinalPlace(final String description,
+                      final Point location,
+                      final LocalDateTime finishTime,
+                      final LocalDateTime resultsTime,
+                      final Integer accessTime) {
         this.description = description;
         this.location = location;
-        this.openingTime = openingTime;
+        this.finishTime = finishTime;
+        this.resultsTime = resultsTime;
+        this.accessTime = accessTime;
     }
 
-    public LocalTime getOpeningTimeOnly() {
-        return openingTime.toLocalTime();
+    public LocalTime getResultsTimeOnly() {
+        return resultsTime.toLocalTime();
     }
 
     public Long getFinalPlaceId() {
@@ -60,14 +76,6 @@ public class FinalPlace {
         this.description = description;
     }
 
-    public LocalDateTime getOpeningTime() {
-        return openingTime;
-    }
-
-    public void setOpeningTime(final LocalDateTime openingTime) {
-        this.openingTime = openingTime;
-    }
-
     public Point getLocation() {
         return location;
     }
@@ -76,13 +84,39 @@ public class FinalPlace {
         this.location = location;
     }
 
+    public LocalDateTime getResultsTime() {
+        return resultsTime;
+    }
+
+    public void setResultsTime(final LocalDateTime resultsTime) {
+        this.resultsTime = resultsTime;
+    }
+
+    public LocalDateTime getFinishTime() {
+        return finishTime;
+    }
+
+    public void setFinishTime(final LocalDateTime finishTime) {
+        this.finishTime = finishTime;
+    }
+
+    public Integer getAccessTime() {
+        return accessTime;
+    }
+
+    public void setAccessTime(final Integer accessTime) {
+        this.accessTime = accessTime;
+    }
+
     @Override
     public String toString() {
         return "FinalPlace{" +
                 "finalPlaceId=" + finalPlaceId +
                 ", description='" + description + '\'' +
                 ", location=" + location +
-                ", openingTime=" + openingTime +
+                ", resultsTime=" + resultsTime +
+                ", finishTime=" + finishTime +
+                ", accessTime=" + accessTime +
                 '}';
     }
 
@@ -98,11 +132,13 @@ public class FinalPlace {
         return Objects.equals(finalPlaceId, that.finalPlaceId) &&
                 Objects.equals(description, that.description) &&
                 Objects.equals(location, that.location) &&
-                Objects.equals(openingTime, that.openingTime);
+                Objects.equals(resultsTime, that.resultsTime) &&
+                Objects.equals(finishTime, that.finishTime) &&
+                Objects.equals(accessTime, that.accessTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(finalPlaceId, description, location, openingTime);
+        return Objects.hash(finalPlaceId, description, location, resultsTime, finishTime, accessTime);
     }
 }

--- a/src/main/java/dk/cngroup/lentils/service/FinalPlaceService.java
+++ b/src/main/java/dk/cngroup/lentils/service/FinalPlaceService.java
@@ -5,12 +5,18 @@ import dk.cngroup.lentils.exception.MoreFinalPlacesException;
 import dk.cngroup.lentils.repository.FinalPlaceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 import java.util.List;
 
 @Service
 public class FinalPlaceService {
 
+    private static final String FINISH_AFTER_RESUTLS_TIME_ERROR =
+            "Čas vyhlášení výsledků musí být až po skončení luštění.";
+    private static final String FINALPLACE_ENTITY = "finalPlace";
+    private static final String RESULTSTIME_PROPERTY = "resultsTime";
     private FinalPlaceRepository finalPlaceRepository;
 
     @Autowired
@@ -38,5 +44,23 @@ public class FinalPlaceService {
 
     public void deleteAll() {
         finalPlaceRepository.deleteAll();
+    }
+
+    public void checkFinishTimeBeforeResultsTime(final BindingResult bindingResult, final FinalPlace finalPlace) {
+        if (!isFinishTimeBeforeResultsTime(finalPlace)) {
+            FieldError error = new FieldError(
+                    FINALPLACE_ENTITY,
+                    RESULTSTIME_PROPERTY,
+                    finalPlace.getFinishTime(),
+                    true,
+                    null,
+                    null,
+                    FINISH_AFTER_RESUTLS_TIME_ERROR);
+            bindingResult.addError(error);
+        }
+    }
+
+    public boolean isFinishTimeBeforeResultsTime(final FinalPlace finalPlace) {
+        return finalPlace.getFinishTime().isBefore(finalPlace.getResultsTime());
     }
 }

--- a/src/main/java/dk/cngroup/lentils/service/GameLogicService.java
+++ b/src/main/java/dk/cngroup/lentils/service/GameLogicService.java
@@ -34,7 +34,7 @@ public class GameLogicService {
     public boolean isGameInProgress() {
         final FinalPlace finalPlace = finalPlaceService.getFinalPlace();
 
-        return finalPlace.getOpeningTime() != null && finalPlace.getOpeningTime().isAfter(LocalDateTime.now());
+        return finalPlace.getFinishTime() != null && finalPlace.getFinishTime().isAfter(LocalDateTime.now());
     }
 
     public boolean allowPlayersToViewFinalPlace(final Team team) {
@@ -49,16 +49,18 @@ public class GameLogicService {
 
     public boolean passedTimeToViewFinalPlace() {
         try {
-            LocalDateTime finalPlaceOpeningTime = finalPlaceService.getFinalPlace().getOpeningTime();
-            return finalPlaceOpeningTime.isBefore(LocalDateTime.now().plusHours(1));
+            LocalDateTime finalPlaceFinishTime = finalPlaceService.getFinalPlace().getFinishTime();
+            int accessMinutes = finalPlaceService.getFinalPlace().getAccessTime();
+
+            return finalPlaceFinishTime.isBefore(LocalDateTime.now().plusMinutes(accessMinutes));
         } catch (Exception e) {
             return false;
         }
     }
 
-    public LocalTime getFinalPlaceOpeningTime() {
+    public LocalTime getFinalPlaceResultsTime() {
         FinalPlace finalPlace = finalPlaceService.getFinalPlace();
-        return finalPlace.getOpeningTime().toLocalTime();
+        return finalPlace.getResultsTime().toLocalTime();
     }
 
     public void initializeGameForTeam(final Team team) {

--- a/src/main/resources/templates/client/cypher/list.html
+++ b/src/main/resources/templates/client/cypher/list.html
@@ -48,7 +48,7 @@
             <div class="container">
                 <div class="row align-items-center">
                     <div id="time" class="col">
-                        <p th:text="${openingTime}"></p>
+                        <p th:text="${resultsTime}"></p>
                     </div>
                     <div id="content" class="col">
                         Vyhlášení výsledků

--- a/src/main/resources/templates/client/finalplace/detail.html
+++ b/src/main/resources/templates/client/finalplace/detail.html
@@ -15,7 +15,7 @@
     <div class="row">
         <div class="col-sm-12">
             <div class="alert alert-danger red" role="alert">
-                <th:block th:text="${'Vyhlášení proběhne dnes v ' + finalplace.getOpeningTimeOnly()}">
+                <th:block th:text="${'Vyhlášení proběhne dnes v ' + finalplace.getResultsTime().toLocalTime()}">
                     
                 </th:block>
             </div>

--- a/src/main/resources/templates/finalplace/form.html
+++ b/src/main/resources/templates/finalplace/form.html
@@ -32,9 +32,19 @@
                     <p class="error" th:if="${#fields.hasErrors('location')}" th:errors="*{location}">Location error.</p>
                 </div>
                 <div class="form-group">
-                    <label for="openingTime" class="input-value-required">Čas</label>
-                    <input id="openingTime" class="form-control" type="datetime-local" placeholder="yyyy-MM-ddTHH:mm" th:field="*{openingTime}" required/>
-                    <p class="error" th:if="${#fields.hasErrors('openingTime')}" th:errors="*{openingTime}">Opening time error.</p>
+                    <label for="finishTime" class="input-value-required">Čas ukončení</label>
+                    <input id="finishTime" class="form-control" type="datetime-local" placeholder="yyyy-MM-ddTHH:mm" th:field="*{finishTime}" required/>
+                    <p class="error" th:if="${#fields.hasErrors('finishTime')}" th:errors="*{finishTime}">Finish time error.</p>
+                </div>
+                <div class="form-group">
+                    <label for="resultsTime" class="input-value-required">Čas vyhlášení</label>
+                    <input id="resultsTime" class="form-control" type="datetime-local" placeholder="yyyy-MM-ddTHH:mm" th:field="*{resultsTime}" required/>
+                    <p class="error" th:if="${#fields.hasErrors('resultsTime')}" th:errors="*{resultsTime}">Results time error.</p>
+                </div>
+                <div class="form-group">
+                    <label for="resultsTime" class="input-value-required">Zpřístupnění místa vyhlášení před časem ukončení (minuty)</label>
+                    <input id="accessTime" class="form-control" type="number" th:field="*{accessTime}" required/>
+                    <p class="error" th:if="${#fields.hasErrors('accessTime')}" th:errors="*{accessTime}">access time error.</p>
                 </div>
                 <button type="submit" class="btn btn-primary">Uložit</button>
             </form>

--- a/src/test/java/dk/cngroup/lentils/controller/ClientControllerSkipCypherIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/controller/ClientControllerSkipCypherIntegrationTest.java
@@ -32,6 +32,7 @@ public class ClientControllerSkipCypherIntegrationTest {
     private static final String FALSE_CODEWORD = "firefly";
     private static final Point TEST_LOCATION = new Point(59.9090442, 10.7423389);
     private static final String HINT_NAME = "abcd";
+    private static final int TEST_FINALPLACE_ACCESS_TIME = 60;
 
     @Autowired
     private ClientController testedController;
@@ -152,7 +153,8 @@ public class ClientControllerSkipCypherIntegrationTest {
         final FinalPlace finalPlace = new FinalPlace();
         finalPlace.setLocation(TEST_LOCATION);
         finalPlace.setDescription("description");
-        finalPlace.setOpeningTime(time);
+        finalPlace.setFinishTime(time);
+        finalPlace.setAccessTime(TEST_FINALPLACE_ACCESS_TIME);
         finalPlaceRepository.save(finalPlace);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/controller/ClientControllerTakeHintIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/controller/ClientControllerTakeHintIntegrationTest.java
@@ -33,6 +33,7 @@ public class ClientControllerTakeHintIntegrationTest {
     private static final Point TEST_LOCATION = new Point(59.9090442, 10.7423389);
     private static final String HINT_NAME = "abcd";
     private static final int HINT_VALUE = 5;
+    private static final int TEST_FINALPLACE_ACCESS_TIME = 60;
 
     @Autowired
     private ClientController testedController;
@@ -155,7 +156,8 @@ public class ClientControllerTakeHintIntegrationTest {
         final FinalPlace finalPlace = new FinalPlace();
         finalPlace.setLocation(TEST_LOCATION);
         finalPlace.setDescription("description");
-        finalPlace.setOpeningTime(time);
+        finalPlace.setFinishTime(time);
+        finalPlace.setAccessTime(TEST_FINALPLACE_ACCESS_TIME);
         finalPlaceRepository.save(finalPlace);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/controller/ClientControllerVerifyCodewordIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/controller/ClientControllerVerifyCodewordIntegrationTest.java
@@ -39,6 +39,7 @@ public class ClientControllerVerifyCodewordIntegrationTest {
     public static final String FALSE_CODEWORD = "firefly";
     private static final Point TEST_LOCATION = new Point(59.9090442, 10.7423389);
     private static final String HINT_NAME = "abcd";
+    private static final int TEST_FINALPLACE_ACCESS_TIME = 60;
 
     @Autowired
     private ClientController testedController;
@@ -201,7 +202,8 @@ public class ClientControllerVerifyCodewordIntegrationTest {
         final FinalPlace finalPlace = new FinalPlace();
         finalPlace.setLocation(TEST_LOCATION);
         finalPlace.setDescription("description");
-        finalPlace.setOpeningTime(time);
+        finalPlace.setFinishTime(time);
+        finalPlace.setAccessTime(TEST_FINALPLACE_ACCESS_TIME);
         finalPlaceRepository.save(finalPlace);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/repository/FinalPlaceRepositoryTest.java
+++ b/src/test/java/dk/cngroup/lentils/repository/FinalPlaceRepositoryTest.java
@@ -51,26 +51,38 @@ public class FinalPlaceRepositoryTest {
 
     @Test(expected = javax.validation.ConstraintViolationException.class)
     public void finalPlaceWithEmptyDescriptionTest() {
-        FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithDescription(TEST_EMPTY_DESCRIPTION);
+        FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setDescription(TEST_EMPTY_DESCRIPTION);
         repository.saveAndFlush(finalPlace);
     }
 
     @Test(expected = javax.validation.ConstraintViolationException.class)
     public void finalPlaceWithTooLongDescriptionTest() {
-        FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithDescription(TEST_TOO_LONG_DESCRIPTION);
+        FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setDescription(TEST_TOO_LONG_DESCRIPTION);
         repository.saveAndFlush(finalPlace);
     }
 
     @Test(expected = javax.validation.ConstraintViolationException.class)
     public void finalPlaceWithEmptyLocationTest() {
-        FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithLocation(null);
+        FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setLocation(null);
         repository.saveAndFlush(finalPlace);
     }
 
     @Test(expected = java.time.format.DateTimeParseException.class)
-    public void finalPlaceWithTimeInInvalidFormatTest() {
-        LocalDateTime openingTime = LocalDateTime.parse(TEST_INVALID_FORMAT);
-        FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithOpeningTime(openingTime);
+    public void finalPlaceWithFinishTimeInInvalidFormatTest() {
+        LocalDateTime finishTime = LocalDateTime.parse(TEST_INVALID_FORMAT);
+        FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setFinishTime(finishTime);
+        repository.saveAndFlush(finalPlace);
+    }
+
+    @Test(expected = java.time.format.DateTimeParseException.class)
+    public void finalPlaceWithResultsTimeInInvalidFormatTest() {
+        LocalDateTime resultsTime = LocalDateTime.parse(TEST_INVALID_FORMAT);
+        FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setResultsTime(resultsTime);
         repository.saveAndFlush(finalPlace);
     }
 

--- a/src/test/java/dk/cngroup/lentils/service/FinalPlaceServiceIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/service/FinalPlaceServiceIntegrationTest.java
@@ -48,7 +48,8 @@ public class FinalPlaceServiceIntegrationTest {
         assertEquals(1, finalPlaceRepository.findAll().size());
 
         final String placeDescription = TEST_DESCRIPTION;
-        final FinalPlace newPlace = objectGenerator.generateFinalPlaceWithDescription(placeDescription);
+        final FinalPlace newPlace = objectGenerator.generateFinalPlace();
+        newPlace.setDescription(placeDescription);
         finalPlaceService.save(newPlace);
 
         final List<FinalPlace> placesAfterSave = finalPlaceRepository.findAll();
@@ -57,18 +58,52 @@ public class FinalPlaceServiceIntegrationTest {
     }
 
     @Test
-    public void shouldBeWithinOneHourBeforeOpeningTime() {
-        LocalDateTime openingTime = LocalDateTime.now().plusMinutes(20);
-        final FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithOpeningTime(openingTime);
+    public void shouldBeWithinConfiguredMinutesBeforeFinishTime() {
+        LocalDateTime finishTime = LocalDateTime.now().plusMinutes(20);
+        final FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setFinishTime(finishTime);
+        finalPlace.setAccessTime(30);
         finalPlaceService.save(finalPlace);
+
         assertTrue(gameLogicService.passedTimeToViewFinalPlace());
     }
 
     @Test
-    public void shouldNotBeWithinOneHourBeforeOpeningTime() {
-        LocalDateTime openingTime = LocalDateTime.now().plusMinutes(61);
-        final FinalPlace finalPlace = objectGenerator.generateFinalPlaceWithOpeningTime(openingTime);
+    public void shouldNotBeWithinConfiguredMinutesBeforeFinishTime() {
+        LocalDateTime finishTime = LocalDateTime.now().plusMinutes(31);
+        final FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setFinishTime(finishTime);
+        finalPlace.setAccessTime(30);
         finalPlaceService.save(finalPlace);
+
         assertFalse(gameLogicService.passedTimeToViewFinalPlace());
+    }
+
+    @Test
+    public void isFinishTimeBeforeResultsTime() {
+        LocalDateTime finishTime = LocalDateTime.now().plusMinutes(10);
+        LocalDateTime resultsTime = LocalDateTime.now().plusMinutes(20);
+        int accessMinutes = 60;
+
+        final FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setFinishTime(finishTime);
+        finalPlace.setResultsTime(resultsTime);
+        finalPlace.setAccessTime(accessMinutes);
+
+        assertTrue(finalPlaceService.isFinishTimeBeforeResultsTime(finalPlace));
+    }
+
+    @Test
+    public void isFinishTimeAfterResultsTime() {
+        LocalDateTime finishTime = LocalDateTime.now().plusMinutes(10);
+        LocalDateTime resultsTime = LocalDateTime.now().plusMinutes(1);
+        int accessMinutes = 60;
+
+        final FinalPlace finalPlace = objectGenerator.generateFinalPlace();
+        finalPlace.setFinishTime(finishTime);
+        finalPlace.setResultsTime(resultsTime);
+        finalPlace.setAccessTime(accessMinutes);
+
+        assertFalse(finalPlaceService.isFinishTimeBeforeResultsTime(finalPlace));
     }
 }

--- a/src/test/java/dk/cngroup/lentils/service/GameLogicServiceIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/service/GameLogicServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 @SpringBootTest(classes = LentilsApplication.class)
 @Transactional
 public class GameLogicServiceIntegrationTest {
+    private static final int TEST_FINALPLACE_ACCESS_TIME = 60;
 
     @Autowired
     private TeamService teamService;
@@ -114,8 +115,9 @@ public class GameLogicServiceIntegrationTest {
     }
 
     private void setFinalPlaceTime(final Long plusMinutes) {
-        LocalDateTime openingTime = LocalDateTime.now().plusMinutes(plusMinutes);
-        final FinalPlace finalPlace = new FinalPlace("desc", new Point(8.5, 5), openingTime);
+        LocalDateTime finishTime = LocalDateTime.now().plusMinutes(plusMinutes);
+        LocalDateTime resultsTime = LocalDateTime.now().plusMinutes(plusMinutes + 15);
+        final FinalPlace finalPlace = new FinalPlace("desc", new Point(8.5, 5), finishTime, resultsTime, TEST_FINALPLACE_ACCESS_TIME);
         finalPlaceService.save(finalPlace);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/service/ObjectGenerator.java
+++ b/src/test/java/dk/cngroup/lentils/service/ObjectGenerator.java
@@ -27,7 +27,8 @@ public class ObjectGenerator {
     public static final int CYPHER_DEFAULT_STAGE = 1;
 
     public static final String FINALPLACE_DESCRIPTION = "konecna stanice - krematorium";
-    public static final LocalDateTime FINALPLACE_OPENING_TIME_FUTURE = LocalDateTime.now().plusMinutes(1);
+    public static final LocalDateTime FINALPLACE_FINISH_TIME_FUTURE = LocalDateTime.now().plusMinutes(1);
+    public static final LocalDateTime FINALPLACE_RESULTS_TIME_FUTURE = LocalDateTime.now().plusMinutes(16);
     public static final Point FINALPLACE_LOCATION = new Point(2.123, 3.456);
 
     public static final int NUMBER_OF_TEAMS = 10;
@@ -117,19 +118,7 @@ public class ObjectGenerator {
     }
 
     public FinalPlace generateFinalPlace() {
-        return new FinalPlace(FINALPLACE_DESCRIPTION, FINALPLACE_LOCATION, FINALPLACE_OPENING_TIME_FUTURE);
-    }
-
-    public FinalPlace generateFinalPlaceWithOpeningTime(final LocalDateTime openingTime) {
-        return new FinalPlace(FINALPLACE_DESCRIPTION, FINALPLACE_LOCATION, openingTime);
-    }
-
-    public FinalPlace generateFinalPlaceWithDescription(final String description) {
-        return new FinalPlace(description, FINALPLACE_LOCATION, FINALPLACE_OPENING_TIME_FUTURE);
-    }
-
-    public FinalPlace generateFinalPlaceWithLocation(final Point location) {
-        return new FinalPlace(FINALPLACE_DESCRIPTION, location, FINALPLACE_OPENING_TIME_FUTURE);
+        return new FinalPlace(FINALPLACE_DESCRIPTION, FINALPLACE_LOCATION, FINALPLACE_FINISH_TIME_FUTURE, FINALPLACE_RESULTS_TIME_FUTURE, 60);
     }
 
     public User createUser(final String username) {


### PR DESCRIPTION
+ Pridan novy field finishTime
+ pridan novy field accessTime -> zpřístupnění finalplace v minutách (da se nastavit, v jake dobe pred ukoncenim lusteni se zobrazi finalplace pro vsechny)

prosim o otestovani:
- tymy nemuzou brat napovedu po uplynuti finishTime
- tymy nemuzou overovat reseni sifer uplynuti finishTime
- tymy muzou zobrazit misto vyhlaseni v čase  > finishTime - accessTime
- tymy nemuzou zobrazit misto vyhlaseni v čase  < finishTime - accessTime
- nelze zahajit hru pro tym po finishTime (client)
- pri updatovani finalplace musi byt finishTime vzdy driv nez resultsTime (admin)
- accessTime nesmi byt zaporny, muze byt 0

Resolves #444 