### PR TITLE
GH-438 Create fragment for GPS coordinates

### DIFF
--- a/src/main/resources/templates/client/cypher/detail.html
+++ b/src/main/resources/templates/client/cypher/detail.html
@@ -82,7 +82,7 @@
         <div class="row">
             <div class="col-sm-12">
                 <h2>Adresa</h2>
-                <p th:text="${'GPS: ' + cypher.location.y + ' ' + cypher.location.x}"></p>
+                <p><span th:replace="fragments/gps-position :: gps(${cypher.location})"></span></p>
                 <p th:text="${cypher.placeDescription}"></p>
                 <div id="map" style='width: 100%; height: 150px;'></div>
                 <a th:href="@{${cypher.mapAddress}}"

--- a/src/main/resources/templates/cypher/list.html
+++ b/src/main/resources/templates/cypher/list.html
@@ -30,7 +30,7 @@
                 <td th:text="${cypher.cypherId}">cypherId</td>
                 <td th:text="${cypher.name}">Jmeno</td>
                 <td th:text="${cypher.stage}">Cislo</td>
-                <td th:text="${cypher.location}">X, Y</td>
+                <td><span th:replace="fragments/gps-position :: gps(${cypher.location})"></span></td>
                 <td th:text="${#strings.abbreviate(cypher.placeDescription,50)}">Popis mista</td>
                 <td th:text="${cypher.codeword}">codove slovo</td>
                 <td th:text="${cypher.trapCodeword}">Past</td>

--- a/src/main/resources/templates/fragments/gps-position.html
+++ b/src/main/resources/templates/fragments/gps-position.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>GPS Fragment</title>
+</head>
+<body>
+    <span th:fragment="gps(point)">
+        GPS: <span th:text="${#numbers.formatDecimal(point.getY(), 0, 6)}">Y</span>, <span th:text="${#numbers.formatDecimal(point.getX(), 0, 6)}">X</span>
+    </span>
+</body>
+</html>


### PR DESCRIPTION
Fixes #438 

Znovupoužitelný fragment pro renderování GPS lokace. Desetinná čísla jsou omezena na 6 číslic, které prý stačí na uchování pozice na ulici (screenshot obsahuje nesprávně 7).

Pohled admin:
![gh-438-admin-cypher-list](https://user-images.githubusercontent.com/46486968/60575787-7242d980-9d7c-11e9-9fef-9c70e9cc1c25.jpg)

Pohled klienta:
![gh-438-client-cypher-detail](https://user-images.githubusercontent.com/46486968/60575797-77a02400-9d7c-11e9-9195-66282fb004d1.jpg)
