### PR TITLE
ScoreItem override equals

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/core/ScoreItem.java
+++ b/src/main/java/dk/cngroup/lentils/entity/core/ScoreItem.java
@@ -3,6 +3,8 @@ package dk.cngroup.lentils.entity.core;
 import dk.cngroup.lentils.entity.view.Rank;
 import dk.cngroup.lentils.entity.view.TeamScore;
 
+import java.util.Objects;
+
 public class ScoreItem implements Comparable {
     private int score;
     private Rank rank;
@@ -27,5 +29,23 @@ public class ScoreItem implements Comparable {
     public int compareTo(final Object o) {
         int compareScore = ((TeamScore) o).getScore();
         return compareScore - getScore();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ScoreItem)) {
+            return false;
+        }
+        ScoreItem scoreItem = (ScoreItem) o;
+        return score == scoreItem.score &&
+                Objects.equals(rank, scoreItem.rank);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(score, rank);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/entity/TeamScoreTest.java
+++ b/src/test/java/dk/cngroup/lentils/entity/TeamScoreTest.java
@@ -1,0 +1,36 @@
+package dk.cngroup.lentils.entity;
+
+import dk.cngroup.lentils.entity.view.TeamScore;
+import dk.cngroup.lentils.service.ObjectGenerator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TeamScoreTest {
+
+    @Test
+    public void testCompareToEquals() {
+        ObjectGenerator og = new ObjectGenerator();
+        Team team1 = og.generateValidTeam();
+        Team team2 = og.generateValidTeam();
+        TeamScore x = new TeamScore(team1, 10);
+        TeamScore y = new TeamScore(team2, 10);
+
+        assertEquals(0, x.compareTo(y));
+        assertTrue(x.equals(y));
+    }
+
+    @Test
+    public void testCompareToEqualsShouldBeFalse() {
+        ObjectGenerator og = new ObjectGenerator();
+        Team team1 = og.generateValidTeam();
+        Team team2 = og.generateValidTeam();
+        TeamScore x = new TeamScore(team1, 10);
+        TeamScore y = new TeamScore(team2, 20);
+
+        assertEquals(10, x.compareTo(y));
+        assertFalse(x.equals(y));
+    }
+}


### PR DESCRIPTION
It is strongly recommended, but not strictly required that (x.compareTo(y)==0) == (x.equals(y)).