### PR TITLE
Remove invalid Cypher constructor

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/Cypher.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Cypher.java
@@ -69,10 +69,6 @@ public class Cypher implements Serializable {
         this.mapAddress = mapAddress;
     }
 
-    public Cypher(final int stage) {
-        this.stage = stage;
-    }
-
     public Cypher(final String name,
                   final int stage,
                   final Point location,

--- a/src/test/java/dk/cngroup/lentils/service/StatusServiceTest.java
+++ b/src/test/java/dk/cngroup/lentils/service/StatusServiceTest.java
@@ -77,7 +77,8 @@ public class StatusServiceTest {
         when(statusRepository.findByTeamAndCypher(any(), any())).thenReturn(statusEntity);
         when(cypherService.getNext(any())).thenThrow(new NextCypherNotFoundException());
 
-        service.markCypher(new Cypher(1), new Team(), CypherStatus.SOLVED);
+        final Cypher cypher = generator.generateValidCypher();
+        service.markCypher(cypher, new Team(), CypherStatus.SOLVED);
 
         assertEquals(CypherStatus.SOLVED, statusEntity.getCypherStatus());
         verify(statusRepository).save(statusEntity);


### PR DESCRIPTION
Smazaný nepotřebný Cypher konstruktor.
Nenastavoval všechny atributy, které jsou NotNull nebo NotEmpty atd.