### PR TITLE
Role delete unnecessary constructor.

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/Role.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Role.java
@@ -20,9 +20,6 @@ public class Role {
     @Column(name = "role")
     private String role;
 
-    public Role() {
-    }
-
     public Long getRoleId() {
         return roleId;
     }


### PR DESCRIPTION
Ve třídě nejsou žádné jiné konstruktory, defaultní tedy není potřeba psát.