### PR TITLE
Rename Role::role attribute to Role::name

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/Role.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Role.java
@@ -18,7 +18,7 @@ public class Role {
     private Long roleId;
 
     @Column(name = "role")
-    private String role;
+    private String name;
 
     public Long getRoleId() {
         return roleId;
@@ -28,11 +28,11 @@ public class Role {
         this.roleId = roleId;
     }
 
-    public String getRole() {
-        return role;
+    public String getName() {
+        return name;
     }
 
-    public void setRole(final String role) {
-        this.role = role;
+    public void setName(final String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/dk/cngroup/lentils/repository/RoleRepository.java
+++ b/src/main/java/dk/cngroup/lentils/repository/RoleRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Long> {
-    Role findByRole(String role);
+    Role findByName(String name);
 }

--- a/src/main/java/dk/cngroup/lentils/repository/UserRepository.java
+++ b/src/main/java/dk/cngroup/lentils/repository/UserRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
-    List<User> findAllByUserIdInAndRolesRole(List<Long> ids, String role);
-    List<User> findAllByRolesRoleOrderByUsername(String role);
+    List<User> findAllByUserIdInAndRolesName(List<Long> ids, String name);
+    List<User> findAllByRolesNameOrderByUsername(String role);
 }

--- a/src/main/java/dk/cngroup/lentils/security/CustomUserDetails.java
+++ b/src/main/java/dk/cngroup/lentils/security/CustomUserDetails.java
@@ -21,7 +21,7 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return user.getRoles()
                 .stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getRole()))
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getName()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/dk/cngroup/lentils/service/RoleService.java
+++ b/src/main/java/dk/cngroup/lentils/service/RoleService.java
@@ -20,7 +20,7 @@ public class RoleService {
 
     public Set<Role> setRole(final String role) {
         Set<Role> roles = new HashSet<>();
-        roles.add(roleRepository.findByRole(role));
+        roles.add(roleRepository.findByName(role));
         return roles;
     }
 }

--- a/src/main/java/dk/cngroup/lentils/service/UserService.java
+++ b/src/main/java/dk/cngroup/lentils/service/UserService.java
@@ -20,10 +20,10 @@ public class UserService {
     }
 
     public List<User> getOrganizers() {
-        return userRepository.findAllByRolesRoleOrderByUsername("ORGANIZER");
+        return userRepository.findAllByRolesNameOrderByUsername("ORGANIZER");
     }
 
     public List<User> getOrganizersByIds(final List<Long> organizerIds) {
-        return userRepository.findAllByUserIdInAndRolesRole(organizerIds, Role.ORGANIZER);
+        return userRepository.findAllByUserIdInAndRolesName(organizerIds, Role.ORGANIZER);
     }
 }

--- a/src/test/java/dk/cngroup/lentils/repository/CypherRepositoryIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/repository/CypherRepositoryIntegrationTest.java
@@ -97,7 +97,7 @@ public class CypherRepositoryIntegrationTest {
         user.setUsername(username);
         user.setPassword(password);
         Set<Role> roles = new HashSet<>();
-        roles.add(roleRepository.findByRole(role));
+        roles.add(roleRepository.findByName(role));
         user.setRoles(roles);
         return user;
     }

--- a/src/test/java/dk/cngroup/lentils/security/CustomUserDetailsTest.java
+++ b/src/test/java/dk/cngroup/lentils/security/CustomUserDetailsTest.java
@@ -41,7 +41,7 @@ public class CustomUserDetailsTest {
     public void testRolesCanBeRetrieved() {
         final User user = new User();
         final Role role = new Role();
-        role.setRole(ROLE_NAME);
+        role.setName(ROLE_NAME);
         user.setRoles(Collections.singleton(role));
         final CustomUserDetails details = createUserDetails(user);
 

--- a/src/test/java/dk/cngroup/lentils/service/UserServiceIntegrationTest.java
+++ b/src/test/java/dk/cngroup/lentils/service/UserServiceIntegrationTest.java
@@ -75,7 +75,7 @@ public class UserServiceIntegrationTest {
         user.setUsername(username);
         user.setPassword(password);
         Set<Role> roles = new HashSet<>();
-        roles.add(roleRepository.findByRole(role));
+        roles.add(roleRepository.findByName(role));
         user.setRoles(roles);
         return user;
     }


### PR DESCRIPTION
Issue v Sonaru:

It's confusing to have a class member with the same name (case differences aside) as its enclosing class. This is particularly so when you consider the common practice of naming a class instance for the class itself.

Best practice dictates that any field or member with the same name as the enclosing class be renamed to be more descriptive of the particular aspect of the class it represents or holds.