### PR TITLE
Implement Serializable interface for JPA entities

### DIFF
--- a/src/main/java/dk/cngroup/lentils/entity/Contact.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Contact.java
@@ -9,11 +9,14 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Entity
 @Table(name = "contact")
-public class Contact {
+public class Contact implements Serializable {
+
+    private static final long serialVersionUID = -4869244705792976490L;
 
     @Id
     @GeneratedValue

--- a/src/main/java/dk/cngroup/lentils/entity/Cypher.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Cypher.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 @Table(name = "cypher")
 public class Cypher implements Serializable {
 
+    private static final long serialVersionUID = 1565385429261533400L;
+
     @Id
     @GeneratedValue
     @Column(name = "cypher_id")

--- a/src/main/java/dk/cngroup/lentils/entity/CypherGameInfoKey.java
+++ b/src/main/java/dk/cngroup/lentils/entity/CypherGameInfoKey.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class CypherGameInfoKey implements Serializable {
+    private static final long serialVersionUID = -958015171952985338L;
+
     private Long cypherId;
     private Long teamId;
 

--- a/src/main/java/dk/cngroup/lentils/entity/FinalPlace.java
+++ b/src/main/java/dk/cngroup/lentils/entity/FinalPlace.java
@@ -7,13 +7,16 @@ import javax.persistence.*;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Objects;
 
 @Entity
 @Table(name = "final_place")
-public class FinalPlace {
+public class FinalPlace implements Serializable {
+
+    private static final long serialVersionUID = 3665569445521724138L;
 
     @Id
     @GeneratedValue

--- a/src/main/java/dk/cngroup/lentils/entity/Hint.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Hint.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 @Table(name = "hint")
 public class Hint implements Serializable {
 
+    private static final long serialVersionUID = -4213650803695289629L;
+
     @Id
     @GeneratedValue
     @Column(name = "hint_id")

--- a/src/main/java/dk/cngroup/lentils/entity/HintTaken.java
+++ b/src/main/java/dk/cngroup/lentils/entity/HintTaken.java
@@ -1,12 +1,15 @@
 package dk.cngroup.lentils.entity;
 
 import javax.persistence.*;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Entity
 @IdClass(HintTakenKey.class)
 @Table(name = "hint_taken")
-public class HintTaken {
+public class HintTaken implements Serializable {
+
+    private static final long serialVersionUID = 3335818559381446168L;
 
     @Id
     @ManyToOne

--- a/src/main/java/dk/cngroup/lentils/entity/HintTakenKey.java
+++ b/src/main/java/dk/cngroup/lentils/entity/HintTakenKey.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class HintTakenKey implements Serializable {
+    private static final long serialVersionUID = 3674555156504574622L;
+
     private Long team;
     private Long hint;
 

--- a/src/main/java/dk/cngroup/lentils/entity/Role.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Role.java
@@ -5,12 +5,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.io.Serializable;
 
 @Entity
 @Table(name = "role")
-public class Role {
+public class Role implements Serializable {
 
     public static final String ORGANIZER = "ORGANIZER";
+    private static final long serialVersionUID = -414272596612800448L;
 
     @Id
     @GeneratedValue

--- a/src/main/java/dk/cngroup/lentils/entity/Status.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Status.java
@@ -1,12 +1,15 @@
 package dk.cngroup.lentils.entity;
 
 import javax.persistence.*;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Entity
 @IdClass(StatusKey.class)
 @Table(name = "status")
-public class Status {
+public class Status implements Serializable {
+
+    private static final long serialVersionUID = 2698218140068854086L;
 
     @Id
     @ManyToOne

--- a/src/main/java/dk/cngroup/lentils/entity/StatusKey.java
+++ b/src/main/java/dk/cngroup/lentils/entity/StatusKey.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class StatusKey implements Serializable {
+    private static final long serialVersionUID = 7422010369350370434L;
+
     private Long cypher;
     private Long team;
 

--- a/src/main/java/dk/cngroup/lentils/entity/Team.java
+++ b/src/main/java/dk/cngroup/lentils/entity/Team.java
@@ -12,11 +12,14 @@ import javax.persistence.Table;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Entity
 @Table(name = "team")
-public class Team {
+public class Team implements Serializable {
+
+    private static final long serialVersionUID = 2479871281907121713L;
 
     @Id
     @GeneratedValue

--- a/src/main/java/dk/cngroup/lentils/entity/User.java
+++ b/src/main/java/dk/cngroup/lentils/entity/User.java
@@ -1,22 +1,15 @@
 package dk.cngroup.lentils.entity;
 
 import javax.persistence.*;
+import java.io.Serializable;
 import java.util.Set;
 
 @Entity
 @SequenceGenerator(name = "seq", initialValue = 500)
 @Table(name = "user_account")
-public class User {
+public class User implements Serializable {
 
-    public User(final User user) {
-        this.password = user.getPassword();
-        this.username = user.getUsername();
-        this.roles = user.getRoles();
-        this.userId = user.getUserId();
-    }
-
-    public User() {
-    }
+    private static final long serialVersionUID = -3350439623038263787L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "seq")

--- a/src/main/java/dk/cngroup/lentils/security/CustomUserDetails.java
+++ b/src/main/java/dk/cngroup/lentils/security/CustomUserDetails.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 public class CustomUserDetails implements UserDetails {
 
+    private static final long serialVersionUID = 3022782814024478720L;
     private final User user;
 
     public CustomUserDetails(final User user) {


### PR DESCRIPTION
Fixes #496 

Entita User by měla implementovat Serializable, protože je použítá v UserDetails.
Do se asi ukládá co jsem pochopil do session atd.

Tím ale by měli být Serializable i další přidružené entity. Bez toho, abych teda udělal nějaký DTO objekt pro přihlášeného uživatele a měnil kód v kontrolerech, tak jsem defenzivně dal Serializable pro všechny JPA entity.